### PR TITLE
Update install.m

### DIFF
--- a/Installation/install.m
+++ b/Installation/install.m
@@ -1,4 +1,4 @@
-version = "Version0.1";
+version = "src";
 
 if ismac
     [brewstatus0,~] = system("which brew");


### PR DESCRIPTION
the version number is no longer required, otherwise, it will result in the following error.
<<
Error using fileread (line 23)
Could not open file Exasim/Version0.1/Matlab/Preprocessing/initializepde.m. No such file or directory.
Error in install (line 81)
text = fileread(filem);
>>