### PR TITLE
add flags for all interfaces

### DIFF
--- a/src/Julia/Gencode/compilecode.jl
+++ b/src/Julia/Gencode/compilecode.jl
@@ -13,6 +13,8 @@ gpucompiler = app.gpucompiler;
 enzyme = app.enzyme;
 cpuflags = app.cpuflags;
 gpuflags = app.gpuflags;
+cpuappflags = app.cpuappflags
+gpuappflags = app.gpuappflags
 
 # current directory
 cdir = pwd();
@@ -51,6 +53,7 @@ if length(cpucompiler)>0
     else
         compilerstr[1] = cpucompiler * " -fPIC -O3 -c opuApp.cpp";
     end    
+    compilerstr[1] = compilerstr[1] * " " * cpuappflags
     compilerstr[2] = "ar -rvs opuApp.a opuApp.o";
 else
     compilerstr[1] = "";
@@ -59,6 +62,7 @@ end
 
 if length(gpucompiler)>0
     compilerstr[3] = gpucompiler * " -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuApp.cu";
+    compilerstr[3] = compilerstr[3] * " " * gpuappflags
     compilerstr[4] = "ar -rvs gpuApp.a gpuApp.o";
 else
     compilerstr[3] = "";

--- a/src/Julia/Gencode/genlib.jl
+++ b/src/Julia/Gencode/genlib.jl
@@ -1,4 +1,4 @@
-function genlib(cpucompiler::String, gpucompiler::String, coredir::String)
+function genlib(cpucompiler::String, gpucompiler::String, coredir::String, cpulibflags::String="", gpulibflags::String="")
 # Examples: genlib("g++","");
 #           genlib("g++","nvcc");
 
@@ -6,13 +6,17 @@ mydir = pwd();
 cd(coredir);
 
 if length(cpucompiler)>0
-    str = `$cpucompiler -fPIC -O3 -c commonCore.cpp`;
-    run(str);
+    str = cpucompiler * " -fPIC -O3 -c commonCore.cpp"
+    str = str * " " * cpulibflags
+    run(string2cmd(str));
+
     str = `ar rvs commonCore.a commonCore.o`;
     run(str);
 
-    str = `$cpucompiler -fPIC -O3 -c opuCore.cpp`;
-    run(str);
+    str = cpucompiler * " -fPIC -O3 -c opuCore.cpp"
+    str = str * " " * cpulibflags
+    run(string2cmd(str));
+
     str = `ar rvs opuCore.a opuCore.o`;
     run(str);
 
@@ -23,8 +27,9 @@ if length(cpucompiler)>0
 end
 
 if length(gpucompiler)>0
-    str = `$gpucompiler -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuCore.cu`;
-    run(str);
+    str = gpucompiler * "-D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuCore.cu";
+    str = str * " " * gpulibflags
+    run(string2cmd(str));
     str = `ar rvs gpuCore.a gpuCore.o `;
     run(str);
 end

--- a/src/Julia/Gencode/setcompilers.jl
+++ b/src/Julia/Gencode/setcompilers.jl
@@ -106,6 +106,8 @@ coredir = mdir[1:ii[end]] * "/lib";
 
 cpulib = 0;
 gpulib = 0;
+cpulibflags = app.cpulibflags
+gpulibflags = app.gpulibflags
 if Sys.isapple()
     if (isfile(coredir * "/Mac/commonCore.a")) && (isfile(coredir * "/Mac/opuCore.a"))
         cpulib = 1;
@@ -131,13 +133,13 @@ end
 
 if cpulib==0
     print("Generating CPU core libraries.");
-    genlib(app.cpucompiler, "", coredir);
+    genlib(app.cpucompiler, "", coredir, cpulibflags);
 end
 
 if gpulib==0
     if (length(app.gpucompiler)>0) && (app.platform == "gpu")
         print("Generating GPU core library.");
-        genlib("", app.gpucompiler, coredir);
+        genlib("", app.gpucompiler, coredir, cpulibflags, gpulibflags);
     end
 end
 

--- a/src/Julia/Preprocessing/initializepde.jl
+++ b/src/Julia/Preprocessing/initializepde.jl
@@ -9,6 +9,10 @@ mutable struct PDEStruct
     mpirun::String;      # Path to MPI run command and MPI run options
     cpuflags::String;    # options for CPU compiler
     gpuflags::String;    # options for GGU compiler
+    cpuappflags::String
+    gpuappflags::String
+    cpulibflags::String
+    gpulibflags::String
     model::String;# used to indicate PDE model
     modelfile::String;# PDE model file name
     modelnumber::IntP;
@@ -142,6 +146,10 @@ function initializepde(version)
     #pde.cpuflags = "-O2 -Wall -ldl -lm -lblas -llapack";
     pde.cpuflags = "-O2 -ldl -lm -lblas -llapack";
     pde.gpuflags = "-lcudart -lcublas";
+    pde.cpuappflags = ""
+    pde.gpuappflags = ""
+    pde.cpulibflags = ""
+    pde.gpulibflags = ""
     pde.modelfile = "";
     pde.preprocessmode = 1;
     pde.mpiprocs = 1;

--- a/src/Matlab/Gencode/compilecode.m
+++ b/src/Matlab/Gencode/compilecode.m
@@ -12,6 +12,8 @@ gpucompiler = app.gpucompiler;
 enzyme = app.enzyme;
 cpuflags = app.cpuflags;
 gpuflags = app.gpuflags;
+cpuappflags = app.cpuappflags;
+gpuappflags = app.gpuappflags;
 
 % current directory
 cdir = pwd();
@@ -51,11 +53,13 @@ if ~isempty(cpucompiler)
     else
         compilerstr{1} = cpucompiler + " -fPIC -O3 -c opuApp.cpp";
     end
+    compilerstr{1} = compilerstr{1} + " " + cpuappflags;
     compilerstr{2} = "ar -rvs opuApp.a opuApp.o";
 end
 
 if ~isempty(gpucompiler)
     compilerstr{3} = gpucompiler + " -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' -w gpuApp.cu";
+    compilerstr{3} = compilerstr{3} + " " + gpuappflags;
     compilerstr{4} = "ar -rvs gpuApp.a gpuApp.o";
 end
 

--- a/src/Matlab/Preprocessing/genlib.m
+++ b/src/Matlab/Preprocessing/genlib.m
@@ -1,20 +1,29 @@
-function genlib(cpucompiler, gpucompiler, coredir)
+function genlib(cpucompiler, gpucompiler, coredir, cpulibflags, gpulibflags)
 % Examples: genlib("g++"); 
 %           genlib("g++","nvcc"); 
+if nargin < 4
+    cpulibflags = "";
+end
+if nargin < 5 
+    gpulibflags = "";
+end
 
 mydir = pwd;
 cd(coredir);
 
 if ~isempty(cpucompiler)
     str = "!" + cpucompiler + " -fPIC -O3 -c commonCore.cpp";
+    str = str + " " + cpulibflags;
     eval(char(str));        
     !ar rvs commonCore.a commonCore.o
 
     str = "!" + cpucompiler + " -fPIC -O3 -c opuCore.cpp";
+    str = str + " " + cpulibflags;
     eval(char(str));    
     !ar rvs opuCore.a opuCore.o
 
     str = "!" + cpucompiler + " -fPIC -O3 -c cpuCore.cpp -fopenmp";
+    str = str + " " + cpulibflags;
     eval(char(str));    
     !ar rvs cpuCore.a cpuCore.o   
     
@@ -35,6 +44,7 @@ end
 
 if ~isempty(gpucompiler)
     str = "!" + gpucompiler + " -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuCore.cu";
+    str = str + " " + gpulibflags;
     eval(char(str));    
     !ar -rvs gpuCore.a gpuCore.o  
     

--- a/src/Matlab/Preprocessing/initializepde.m
+++ b/src/Matlab/Preprocessing/initializepde.m
@@ -17,6 +17,10 @@ pde.appname = "app";
 pde.platform = "cpu";
 pde.cpuflags = "-O2 -ldl -lm -lblas -llapack";
 pde.gpuflags = "-lcudart -lcublas";
+pde.cpuappflags = "";
+pde.gpuappflags = "";
+pde.cpulibflags = "";
+pde.gpulibflags = "";
 pde.pdemodel="ModelD";
 pde.modelnumber = 0;
 

--- a/src/Matlab/Preprocessing/setcompilers.m
+++ b/src/Matlab/Preprocessing/setcompilers.m
@@ -110,6 +110,8 @@ coredir = mdir(1:(ii+5)) + "/lib";
 
 cpulib = 0;
 gpulib = 0;
+cpulibflags = app.cpulibflags;
+gpulibflags = app.gpulibflags;
 if ismac    
     if (exist(coredir + "/Mac/commonCore.a", 'file') == 2) && (exist(coredir + "/Mac/opuCore.a", 'file') == 2)
         cpulib = 1;
@@ -135,13 +137,13 @@ end
 
 if cpulib==0    
     disp("Generating CPU core libraries.");
-    genlib(app.cpucompiler, [], coredir);
+    genlib(app.cpucompiler, [], coredir, cpulibflags);
 end
 
 if gpulib==0        
     if (~isempty(app.gpucompiler)) && (app.platform == "gpu")
         disp("Generating GPU core library.");
-        genlib([], app.gpucompiler, coredir);
+        genlib([], app.gpucompiler, coredir, cpulibflags, gpulibflags);
     end
 end
 

--- a/src/Python/Gencode/compilecode.py
+++ b/src/Python/Gencode/compilecode.py
@@ -18,6 +18,8 @@ def compilecode(app):
     enzyme = app['enzyme'];
     cpuflags = app['cpuflags'];
     gpuflags = app['gpuflags'];
+    cpuappflags = app['cpuappflags']
+    gpuappflags = app['gpuappflags']
 
     # current directory
     cdir = os.getcwd();
@@ -50,6 +52,7 @@ def compilecode(app):
             compilerstr[0] = cpucompiler + " -D _ENZYME -fPIC -O3 -c opuApp.cpp" + " -Xclang -load -Xclang " + coredir + enzyme;
         else:
             compilerstr[0] = cpucompiler + " -fPIC -O3 -c opuApp.cpp";
+        compilerstr[0] = compilerstr[0] + " " + cpuappflags
         compilerstr[1] = "ar -rvs opuApp.a opuApp.o";        
     else:
         compilerstr[0] = "";
@@ -57,6 +60,7 @@ def compilecode(app):
 
     if  size(gpucompiler)>0:
         compilerstr[2] = gpucompiler + " -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuApp.cu";
+        compilerstr[2] = compilerstr[2] + " " + gpuappflags
         compilerstr[3] = "ar -rvs gpuApp.a gpuApp.o";
     else:
         compilerstr[2] = "";

--- a/src/Python/Gencode/genlib.py
+++ b/src/Python/Gencode/genlib.py
@@ -1,24 +1,27 @@
 import os
 from sys import platform
 
-def genlib(cpucompiler, gpucompiler, coredir):
+def genlib(cpucompiler, gpucompiler, coredir, cpulibflags="", gpulibflags=""):
 
     mydir = os.getcwd();
     os.chdir(coredir);
 
     if len(cpucompiler)>0:
         str = cpucompiler + " -fPIC -O3 -c commonCore.cpp";
+        str = str + " " + cpulibflags
         os.system(str);
         str = "ar rvs commonCore.a commonCore.o";
         os.system(str);
 
         str = cpucompiler + " -fPIC -O3 -c opuCore.cpp";
+        str = str + " " + cpulibflags
         os.system(str);
         str = "ar rvs opuCore.a opuCore.o";
         os.system(str);
 
     if len(gpucompiler)>0:
         str = gpucompiler + " -D_FORCE_INLINES -O3 -c --compiler-options '-fPIC' gpuCore.cu";
+        str = str + " " + gpulibflags
         os.system(str);
         str = "ar rvs gpuCore.a gpuCore.o";
         os.system(str);

--- a/src/Python/Gencode/setcompilers.py
+++ b/src/Python/Gencode/setcompilers.py
@@ -107,6 +107,8 @@ def setcompilers(app):
 
     cpulib = 0;
     gpulib = 0;
+    cpulibflags = app['cpulibflags']
+    gpulibflags = app['gpulibflags']
     if platform == "darwin":
         if (os.path.isfile(coredir + "/Mac/commonCore.a")) and (os.path.isfile(coredir + "/Mac/opuCore.a")):
             cpulib = 1;
@@ -125,11 +127,11 @@ def setcompilers(app):
 
     if cpulib==0:
         print("Generating CPU core libraries.");
-        genlib(app['cpucompiler'], "", coredir);
+        genlib(app['cpucompiler'], "", coredir, cpulibflags);
 
     if gpulib==0:
         if (len(app['gpucompiler'])>0) and (app['platform'] == "gpu"):
             print("Generating GPU core library.");
-            genlib("", app['gpucompiler'], coredir);
+            genlib("", app['gpucompiler'], coredir, cpulibflags, gpulibflags);
 
     return app

--- a/src/Python/Preprocessing/initializepde.py
+++ b/src/Python/Preprocessing/initializepde.py
@@ -23,6 +23,10 @@ def initializepde(version):
     #pde['cpuflags'] = "-O2 -Wall -ldl -lm -lblas -llapack";
     pde['cpuflags'] = "-O2 -ldl -lm -lblas -llapack";
     pde['gpuflags'] = "-lcudart -lcublas";
+    pde['cpuappflags'] = ""
+    pde['gpuappflags'] = ""
+    pde['cpulibflags'] = ""
+    pde['gpulibflags'] = ""
 
     pde['usecmake'] = 0;
     pde['buildexec'] = 0;


### PR DESCRIPTION
Adds the following fields to the pde struct: 

pde.cpuappflags
pde.gpuappflags
pde.cpulibflags
pde.gpulibflags

The first two are flags specified by the user that get added to the compilation of opuApp and gpuApp. The second two are flags that get passed to compilation of Exasim libraries in genlib files. All fields default to empty strings. 

Closes #29 